### PR TITLE
Exclude x64Stackalign.asm if not compiling for x64

### DIFF
--- a/NativeBootstrap.vcxproj
+++ b/NativeBootstrap.vcxproj
@@ -224,7 +224,9 @@
     <None Include="NativeBootstrap.licenseheader" />
   </ItemGroup>
   <ItemGroup>
-    <MASM Include="Source\Bootstrap\x64Stackalign.asm" />
+    <MASM Include="Source\Bootstrap\x64Stackalign.asm">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </MASM>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
This broke the Win32 build of NativeBootstrap - I manually added a conditional statement to the MSBuild file (using the same indentation VS does) as documented on http://stackoverflow.com/questions/21504884/how-to-conditionally-include-masm-asm-files-depending-on-platform-configuration to not mangle VS loading/saving too much.